### PR TITLE
Changed Macao's Country Code from MCO to MAC.

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -1195,7 +1195,7 @@ public enum CountryCode
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#MO">MO</a>, MCO, 492,
      * Officially assigned]
      */
-    MO("Macao", "MCO", 446, Assignment.OFFICIALLY_ASSIGNED),
+    MO("Macao", "MAC", 446, Assignment.OFFICIALLY_ASSIGNED),
 
     /**
      * <a href="http://en.wikipedia.org/wiki/Northern_Mariana_Islands">Northern Mariana Islands</a>


### PR DESCRIPTION
I am Importing this class into a database as a starting point - this element broke a unique key, so I've looked it up and amended it.

Thanks
Andrew
