### PR TITLE
Bundleized the build so the jar can be used in an OSGi container.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.neovisionaries</groupId>
     <artifactId>nv-i18n</artifactId>
     <version>1.12-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>Neo Visionaries Internationalization Package</name>
     <description>Package to support internationalization</description>
     <url>https://github.com/TakahikoKawasaki/nv-i18n</url>
@@ -104,6 +104,12 @@
                 <configuration>
                     <additionalJOption>-J-Duser.language=en</additionalJOption>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The packaging change from 'jar' to 'bundle' triggers the maven-bundle-plugin to add the right OSGi headers to the jar. It's still a jar with a bit more metadata.
