### PR TITLE
add undefine for all the enums

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -99,7 +99,7 @@ public enum CountryCode
      * Undefine/Unspecified
      */
     //which one is better?
-    Undefine("Undefine", "Undefine", -1, Assignment.USER_ASSIGNED),
+    UNDEFINED("Undefined", "Undefined", -1, Assignment.USER_ASSIGNED),
     //XX("Undefine", "XXX", -1, Assignment.USER_ASSIGNED)
 
     /**

--- a/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
@@ -50,7 +50,7 @@ public enum CurrencyCode
     /**
      * Undefine
      */
-    UNDEFINE("Undefine", -1, -1),
+    UNDEFINED("Undefined", -1, -1),
     
     /**
      * <a href="http://en.wikipedia.org/wiki/United_Arab_Emirates_dirham">UAE Dirham</a>.

--- a/src/main/java/com/neovisionaries/i18n/LanguageAlpha3Code.java
+++ b/src/main/java/com/neovisionaries/i18n/LanguageAlpha3Code.java
@@ -171,12 +171,12 @@ public enum LanguageAlpha3Code
     /**
      *
      */
-    undefine("Undefine")
+    undefined("Undefined")
     {
         @Override
         public LanguageCode getAlpha2()
         {
-            return LanguageCode.undefine;
+            return LanguageCode.undefined;
         }
     },
 

--- a/src/main/java/com/neovisionaries/i18n/LanguageCode.java
+++ b/src/main/java/com/neovisionaries/i18n/LanguageCode.java
@@ -69,12 +69,12 @@ public enum LanguageCode
     /**
      *
      */
-    undefine()
+    undefined()
     {
         @Override
         public LanguageAlpha3Code getAlpha3()
         {
-            return LanguageAlpha3Code.undefine;
+            return LanguageAlpha3Code.undefined;
         }
     },
     

--- a/src/main/java/com/neovisionaries/i18n/LocaleCode.java
+++ b/src/main/java/com/neovisionaries/i18n/LocaleCode.java
@@ -74,7 +74,7 @@ public enum LocaleCode
    /**
      * undefine
      */
-    undefine(LanguageCode.undefine, CountryCode.Undefine)
+    undefined(LanguageCode.undefined, CountryCode.UNDEFINED)
     {
         @Override
         public Locale toLocale()

--- a/src/main/java/com/neovisionaries/i18n/ScriptCode.java
+++ b/src/main/java/com/neovisionaries/i18n/ScriptCode.java
@@ -33,9 +33,9 @@ public enum ScriptCode
 {
 
     /**
-     * Undefine [-1]
+     * Undefined [-1]
      */
-    Undefine(-1, "Undefine"),
+    Undefined(-1, "Undefined"),
 
     /**
      * Afaka [439]


### PR DESCRIPTION
when we use these enums on annotation, we want an undefine option since the Java's annotation does not support null value.
