### PR TITLE
Support user-assigned country codes. (See issue #25.)

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -92,7 +92,7 @@ import java.util.regex.Pattern;
  *
  * @author Takahiko Kawasaki
  */
-public enum CountryCode
+public enum CountryCode implements CountryCodeInterface
 {
 
     /**
@@ -2150,14 +2150,20 @@ public enum CountryCode
     }
 
 
-    private static final Map<String, CountryCode> alpha3Map = new HashMap<String, CountryCode>();
-    private static final Map<Integer, CountryCode> numericMap = new HashMap<Integer, CountryCode>();
-
+    private static final Map<String, CountryCodeInterface> alpha2Map = new HashMap<String, CountryCodeInterface>();
+    private static final Map<String, CountryCodeInterface> alpha3Map = new HashMap<String, CountryCodeInterface>();
+    private static final Map<Integer, CountryCodeInterface> numericMap = new HashMap<Integer, CountryCodeInterface>();
+    private static final List<CountryCodeInterface> standardAndUserAssignedCodes = new ArrayList<CountryCodeInterface>();
 
     static
     {
         for (CountryCode cc : values())
         {
+            if (cc.getAlpha2() != null)
+            {
+                alpha2Map.put(cc.getAlpha2(), cc);
+            }
+
             if (cc.getAlpha3() != null)
             {
                 alpha3Map.put(cc.getAlpha3(), cc);
@@ -2167,6 +2173,8 @@ public enum CountryCode
             {
                 numericMap.put(cc.getNumeric(), cc);
             }
+            
+            standardAndUserAssignedCodes.add(cc);
         }
     }
 
@@ -2191,6 +2199,8 @@ public enum CountryCode
      *
      * @return
      *         The country name.
+     *         
+     * @see com.neovisionaries.i18n.CountryCodeInterface#getName()
      */
     public String getName()
     {
@@ -2207,6 +2217,8 @@ public enum CountryCode
      *         >ISO 3166-1 alpha-2</a> code.
      *         {@link CountryCode#UNDEFINED} returns {@code "UNDEFINED"}
      *         which is not an official ISO 3166-1 alpha-2 code.
+     *         
+     * @see com.neovisionaries.i18n.CountryCodeInterface#getAlpha2()
      */
     public String getAlpha2()
     {
@@ -2224,6 +2236,8 @@ public enum CountryCode
      *         Some country codes reserved exceptionally (such as {@link #EU})
      *         returns {@code null}.
      *         {@link CountryCode#UNDEFINED} returns {@code null}, too.
+     *         
+     * @see com.neovisionaries.i18n.CountryCodeInterface#getAlpha3()
      */
     public String getAlpha3()
     {
@@ -2241,6 +2255,8 @@ public enum CountryCode
      *         Country codes reserved exceptionally (such as {@link #EU})
      *         returns {@code -1}.
      *         {@link CountryCode#UNDEFINED} returns {@code -1}, too.
+     *
+     * @see com.neovisionaries.i18n.CountryCodeInterface#getNumeric()
      */
     public int getNumeric()
     {
@@ -2256,6 +2272,8 @@ public enum CountryCode
      *
      * @see <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Decoding_table"
      *       >Decoding table of ISO 3166-1 alpha-2 codes</a>
+     *
+     * @see com.neovisionaries.i18n.CountryCodeInterface#getAssignment()
      */
     public Assignment getAssignment()
     {
@@ -2338,6 +2356,8 @@ public enum CountryCode
      *
      * @return
      *         A {@code Locale} instance that matches this {@code CountryCode}.
+     *
+     * @see com.neovisionaries.i18n.CountryCodeInterface#toLocale()
      */
     public Locale toLocale()
     {
@@ -2377,6 +2397,8 @@ public enum CountryCode
      * @since 1.4
      *
      * @see Currency#getInstance(Locale)
+     *
+     * @see com.neovisionaries.i18n.CountryCodeInterface#getCurrency()
      */
     public Currency getCurrency()
     {
@@ -2416,7 +2438,7 @@ public enum CountryCode
      *
      * @see #getByCode(String, boolean)
      */
-    public static CountryCode getByCode(String code)
+    public static CountryCodeInterface getByCode(String code)
     {
         return getByCode(code, true);
     }
@@ -2443,7 +2465,7 @@ public enum CountryCode
      *
      * @see #getByCode(String, boolean)
      */
-    public static CountryCode getByCodeIgnoreCase(String code)
+    public static CountryCodeInterface getByCodeIgnoreCase(String code)
     {
         return getByCode(code, false);
     }
@@ -2471,7 +2493,7 @@ public enum CountryCode
      * @return
      *         A {@code CountryCode} instance, or {@code null} if not found.
      */
-    public static CountryCode getByCode(String code, boolean caseSensitive)
+    public static CountryCodeInterface getByCode(String code, boolean caseSensitive)
     {
         if (code == null)
         {
@@ -2518,7 +2540,7 @@ public enum CountryCode
      *
      * @see Locale#getCountry()
      */
-    public static CountryCode getByLocale(Locale locale)
+    public static CountryCodeInterface getByLocale(Locale locale)
     {
         if (locale == null)
         {
@@ -2571,20 +2593,13 @@ public enum CountryCode
     }
 
 
-    private static CountryCode getByAlpha2Code(String code)
+    private static CountryCodeInterface getByAlpha2Code(String code)
     {
-        try
-        {
-            return Enum.valueOf(CountryCode.class, code);
-        }
-        catch (IllegalArgumentException e)
-        {
-            return null;
-        }
+        return alpha2Map.get(code);
     }
 
 
-    private static CountryCode getByAlpha3Code(String code)
+    private static CountryCodeInterface getByAlpha3Code(String code)
     {
         return alpha3Map.get(code);
     }
@@ -2603,7 +2618,7 @@ public enum CountryCode
      *         A {@code CountryCode} instance, or {@code null} if not found.
      *         If 0 or a negative value is given, {@code null} is returned.
      */
-    public static CountryCode getByCode(int code)
+    public static CountryCodeInterface getByCode(int code)
     {
         if (code <= 0)
         {
@@ -2637,7 +2652,7 @@ public enum CountryCode
      *
      * @since 1.11
      */
-    public static List<CountryCode> findByName(String regex)
+    public static List<CountryCodeInterface> findByName(String regex)
     {
         if (regex == null)
         {
@@ -2688,16 +2703,16 @@ public enum CountryCode
      *
      * @since 1.11
      */
-    public static List<CountryCode> findByName(Pattern pattern)
+    public static List<CountryCodeInterface> findByName(Pattern pattern)
     {
         if (pattern == null)
         {
             throw new IllegalArgumentException("pattern is null.");
         }
 
-        List<CountryCode> list = new ArrayList<CountryCode>();
+        List<CountryCodeInterface> list = new ArrayList<CountryCodeInterface>();
 
-        for (CountryCode entry : values())
+        for (CountryCodeInterface entry : standardAndUserAssignedCodes)
         {
             // If the name matches the given pattern.
             if (pattern.matcher(entry.getName()).matches())
@@ -2707,5 +2722,25 @@ public enum CountryCode
         }
 
         return list;
+    }
+    
+    public static void addUserAssigned(CountryCodeInterface code)
+    {
+	standardAndUserAssignedCodes.add(code);
+
+	if (!alpha3Map.containsKey(code.getAlpha3()))
+	{
+	    alpha3Map.put(code.getAlpha3(), code);
+	}
+
+	if (!alpha2Map.containsKey(code.getAlpha2()))
+	{
+	    alpha2Map.put(code.getAlpha2(), code);
+	}
+
+	if (!numericMap.containsKey(code.getNumeric()))
+	{
+	    numericMap.put(code.getNumeric(), code);
+	}
     }
 }

--- a/src/main/java/com/neovisionaries/i18n/CountryCodeInterface.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCodeInterface.java
@@ -1,0 +1,102 @@
+package com.neovisionaries.i18n;
+
+import java.util.Currency;
+import java.util.Locale;
+
+import com.neovisionaries.i18n.CountryCode.Assignment;
+
+public interface CountryCodeInterface {
+
+	/**
+	 * Get the country name.
+	 *
+	 * @return The country name.
+	 */
+	String getName();
+
+	/**
+	 * Get the <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
+	 * >ISO 3166-1 alpha-2</a> code.
+	 *
+	 * @return The standard <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
+	 *         >ISO 3166-1 alpha-2</a> code or one which is
+	 * <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Reserved_and_user-assigned_code_elements">reserved
+	 * or user-assigned</a>. {@link CountryCode#UNDEFINED} returns
+	 * {@code "UNDEFINED"} which is not an official ISO 3166-1 alpha-2 code.
+	 */
+	String getAlpha2();
+
+	/**
+	 * Get the <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-3"
+	 * >ISO 3166-1 alpha-3</a> code.
+	 *
+	 * @return The standard <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-3"
+	 *         >ISO 3166-1 alpha-3</a> code or one which is
+	 * <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Reserved_and_user-assigned_code_elements">reserved
+	 * or user-assigned</a>. Some country codes reserved exceptionally (such as
+	 * {@link #EU}) returns {@code null}. {@link CountryCode#UNDEFINED} returns
+	 * {@code null}, too.
+	 */
+	String getAlpha3();
+
+	/**
+	 * Get the <a href="http://en.wikipedia.org/wiki/ISO_3166-1_numeric"
+	 * >ISO 3166-1 numeric</a> code.
+	 *
+	 * @return The standard <a href="http://en.wikipedia.org/wiki/ISO_3166-1_numeric"
+	 *         >ISO 3166-1 numeric</a> code or one which is
+	 * <a href="https://en.wikipedia.org/wiki/ISO_3166-1#Reserved_and_user-assigned_code_elements">reserved
+	 * or user-assigned</a>. Country codes reserved exceptionally (such as
+	 * {@link #EU}) returns {@code -1}. {@link CountryCode#UNDEFINED} returns
+	 * {@code -1}, too.
+	 */
+	int getNumeric();
+
+	/**
+	 * Get the assignment state of this country code in ISO 3166-1.
+	 *
+	 * @return The assignment state.
+	 *
+	 * @see <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Decoding_table"
+	 *       >Decoding table of ISO 3166-1 alpha-2 codes</a>
+	 */
+	Assignment getAssignment();
+
+	/**
+	 * Convert this {@code CountryCode} instance to a {@link Locale} instance.
+	 *
+	 * @return A {@code Locale} instance that matches this {@code CountryCode}.
+	 */
+	Locale toLocale();
+
+	/**
+	 * Get the currency.
+	 *
+	 * <p>
+	 * This method is an alias of {@link Currency}{@code .}{@link
+	 * Currency#getInstance(Locale) getInstance}{@code (}{@link
+	 * #toLocale()}{@code )}. The only difference is that this method returns
+	 * {@code null} when {@code Currency.getInstance(Locale)} throws
+	 * {@code IllegalArgumentException}.
+	 * </p>
+	 *
+	 * <p>
+	 * This method returns {@code null} when the territory represented by this
+	 * {@code CountryCode} instance does not have a currency. {@link #AQ}
+	 * (Antarctica) is one example.
+	 * </p>
+	 *
+	 * <p>
+	 * In addition, this method returns {@code null} also when the ISO 3166 code
+	 * represented by this {@code CountryCode} instance is not supported by the
+	 * implementation of {@link
+	 * Currency#getInstance(Locale)}. At the time of this writing, {@link #SS}
+	 * (South Sudan) is one example.
+	 * </p>
+	 *
+	 * @return A {@code Currency} instance. In some cases, null is returned.
+	 *
+	 * @see Currency#getInstance(Locale)
+	 */
+	Currency getCurrency();
+}

--- a/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
@@ -2591,7 +2591,7 @@ public enum CurrencyCode
      *         {@code CurrencyCode} instance whose country list contains
      *         the specified country, the size of the returned list is zero.
      */
-    public static List<CurrencyCode> getByCountry(CountryCode country)
+    public static List<CurrencyCode> getByCountry(CountryCodeInterface country)
     {
         List<CurrencyCode> list = new ArrayList<CurrencyCode>();
 
@@ -2602,7 +2602,7 @@ public enum CurrencyCode
 
         for (CurrencyCode currency : values())
         {
-            for (CountryCode cc : currency.countryList)
+            for (CountryCodeInterface cc : currency.countryList)
             {
                 if (cc == country)
                 {

--- a/src/main/java/com/neovisionaries/i18n/LocaleCode.java
+++ b/src/main/java/com/neovisionaries/i18n/LocaleCode.java
@@ -992,7 +992,7 @@ public enum LocaleCode
      *         The country code. This method may return null.
      *         For example, {@link #en LocaleCode.en}.getCountry() returns null.
      */
-    public CountryCode getCountry()
+    public CountryCodeInterface getCountry()
     {
         return country;
     }
@@ -1643,7 +1643,7 @@ public enum LocaleCode
      *
      * @since 1.3
      */
-    public static List<LocaleCode> getByCountry(CountryCode country)
+    public static List<LocaleCode> getByCountry(CountryCodeInterface country)
     {
         List<LocaleCode> list = new ArrayList<LocaleCode>();
 

--- a/src/test/java/com/neovisionaries/i18n/CountryCodeTest.java
+++ b/src/test/java/com/neovisionaries/i18n/CountryCodeTest.java
@@ -23,17 +23,53 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
 
+import com.neovisionaries.i18n.CountryCode.Assignment;
+
 
 public class CountryCodeTest
 {
+	private static CountryCodeInterface createUserAssignedCountryCode() {
+		return new CountryCodeInterface() {
+			public String getName() {
+				return "USER_COUNTRY_CODE_1";
+			}
+
+			public String getAlpha2() {
+				return "ZZ";
+			}
+
+			public String getAlpha3() {
+				return "ZZZ";
+			}
+
+			public int getNumeric() {
+				return 999;
+			}
+
+			public Assignment getAssignment() {
+				return Assignment.USER_ASSIGNED;
+			}
+
+			public Locale toLocale() {
+				return null;
+			}
+
+			public Currency getCurrency() {
+				return null;
+			}
+		};
+	}
+
     @Test
     public void test1()
     {
-        List<CountryCode> list = CountryCode.findByName(".*United.*");
+        List<CountryCodeInterface> list = CountryCode.findByName(".*United.*");
 
         assertEquals(6, list.size());
 
@@ -185,4 +221,37 @@ public class CountryCodeTest
     {
         assertNull(getByCode(""));
     }
+    
+	@Test
+	public void testUserAssignedCountryCodeGetByCodeAlpha2() {
+		final CountryCodeInterface expected = createUserAssignedCountryCode();
+		CountryCode.addUserAssigned(expected);
+		final CountryCodeInterface actual = CountryCode.getByCode("ZZ");
+		assertEquals("ZZ", actual.getAlpha2());
+		assertEquals("ZZZ", actual.getAlpha3());
+		assertEquals(999, actual.getNumeric());
+		assertEquals(Assignment.USER_ASSIGNED, actual.getAssignment());
+	}
+
+	@Test
+	public void testUserAssignedCountryCodeGetByCodeAlpha3() {
+		final CountryCodeInterface expected = createUserAssignedCountryCode();
+		CountryCode.addUserAssigned(expected);
+		final CountryCodeInterface actual = CountryCode.getByCode("ZZZ");
+		assertEquals("ZZ", actual.getAlpha2());
+		assertEquals("ZZZ", actual.getAlpha3());
+		assertEquals(999, actual.getNumeric());
+		assertEquals(Assignment.USER_ASSIGNED, actual.getAssignment());
+	}
+
+	@Test
+	public void testUserAssignedCountryCodeGetByCodeNumeric() {
+		final CountryCodeInterface expected = createUserAssignedCountryCode();
+		CountryCode.addUserAssigned(expected);
+		final CountryCodeInterface actual = CountryCode.getByCode(999);
+		assertEquals("ZZ", actual.getAlpha2());
+		assertEquals("ZZZ", actual.getAlpha3());
+		assertEquals(999, actual.getNumeric());
+		assertEquals(Assignment.USER_ASSIGNED, actual.getAssignment());
+	}
 }

--- a/src/test/java/com/neovisionaries/i18n/LocaleCodeTest.java
+++ b/src/test/java/com/neovisionaries/i18n/LocaleCodeTest.java
@@ -129,7 +129,7 @@ public class LocaleCodeTest
     public void test4()
     {
         List<LocaleCode> expected = new ArrayList<LocaleCode>();
-        List<LocaleCode> actual = getByCountry((CountryCode)null);
+        List<LocaleCode> actual = getByCountry((CountryCodeInterface)null);
 
         assertListEquals(expected, actual);
     }


### PR DESCRIPTION
Takahiko, I implemented support for user-assigned country codes.  I followed the example in [How to extend enum in Java](http://blog.pengyifan.com/how-to-extend-enum-in-java/) which is based on the pattern described in [Mixing-in an Enum](https://blogs.oracle.com/darcy/entry/enums_and_mixins).