### PR TITLE
Fixing Kosovo's Alpha-3 code (XKX).

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -2104,7 +2104,7 @@ public enum CountryCode
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#XK">XK</a>, XXK, -1,
      * User assigned]
      */
-    XK("Kosovo, Republic of", "XXK", -1, Assignment.USER_ASSIGNED),
+    XK("Kosovo, Republic of", "XKX", -1, Assignment.USER_ASSIGNED),
 
     /**
      * <a href="http://en.wikipedia.org/wiki/Yemen">Yemen</a>


### PR DESCRIPTION
Somehow, this is XXK instead of XKX, which I stumbled over accidentally.