### PR TITLE
Added mapping of country code 280 to DE.

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -2279,6 +2279,9 @@ public enum CountryCode
 
         // TL and TP have the same numeric code 626. TL should be used.
         numericMap.put(Integer.valueOf(626), TL);
+        
+        // County code 280 is also used for DE by the German banking industry.
+        numericMap.put(Integer.valueOf(280), DE);
     }
 
 

--- a/src/test/java/com/neovisionaries/i18n/CountryCodeTest.java
+++ b/src/test/java/com/neovisionaries/i18n/CountryCodeTest.java
@@ -378,4 +378,10 @@ public class CountryCodeTest
         assertEquals(826, CountryCode.UK.getNumeric());
         assertEquals(180, CountryCode.ZR.getNumeric());
     }
+
+    @Test
+    public void test42() {
+        // Country code 280 should map to 278, due to legacy applications in payment industry.
+        assertEquals(CountryCode.DE, CountryCode.getByCode(280));
+    }
 }


### PR DESCRIPTION
See https://www.girocard.eu/media/weiternutzung_iso3166-code-280_deutschland.pdf
for more details.