### PR TITLE
add java @Deprecated annotations to deprecated currencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+nv-i18n.iml

--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -193,7 +193,9 @@ public enum CountryCode
      * Since version 1.16, the value of alpha-3 code of this entry is {@code ANT}
      * (not <code><a href="http://en.wikipedia.org/wiki/ISO_3166-3#ANHH">ANHH</a></code>).
      * </p>
+     * @deprecated
      */
+    @Deprecated
     AN("Netherlands Antilles", "ANT", 530, Assignment.TRANSITIONALLY_RESERVED),
 
     /**
@@ -394,7 +396,9 @@ public enum CountryCode
      * </p>
      *
      * @see #MM
+     * @deprecated
      */
+    @Deprecated
     BU("Burma", "BUR", 104, Assignment.TRANSITIONALLY_RESERVED),
 
     /**
@@ -548,7 +552,9 @@ public enum CountryCode
      * Since version 1.16, the value of alpha-3 code of this entry is {@code SCG}
      * (not <code><a href="http://en.wikipedia.org/wiki/ISO_3166-3#CSXX">CSXX</a></code>).
      * </p>
+     * @deprecated
      */
+    @Deprecated
     CS("Serbia and Montenegro", "SCG", 891, Assignment.TRANSITIONALLY_RESERVED),
 
     /**
@@ -1490,7 +1496,9 @@ public enum CountryCode
      * Since version 1.16, the value of alpha-3 code of this entry is {@code NTZ}
      * (not <code><a href="http://en.wikipedia.org/wiki/ISO_3166-3#NTHH">NTHH</a></code>).
      * </p>
+     * @deprecated
      */
+    @Deprecated
     NT("Neutral Zone", "NTZ", 536, Assignment.TRANSITIONALLY_RESERVED),
 
     /**
@@ -1695,7 +1703,9 @@ public enum CountryCode
      * Traditionally reserved]
      *
      * @see #FI
+     * @deprecated
      */
+    @Deprecated
     SF("Finland", "FIN", 246, Assignment.TRANSITIONALLY_RESERVED),
 
     /**
@@ -1922,7 +1932,9 @@ public enum CountryCode
      * </p>
      *
      * @see #TL
+     * @deprecated
      */
+    @Deprecated
     TP("East Timor", "TMP", 626, Assignment.TRANSITIONALLY_RESERVED),
 
     /**
@@ -2129,7 +2141,9 @@ public enum CountryCode
      * Since version 1.16, the value of alpha-3 code of this entry is {@code YUG}
      * (not <code><a href="http://en.wikipedia.org/wiki/ISO_3166-3#YUCS">YUCS</a></code>).
      * </p>
+     * @deprecated
      */
+    @Deprecated
     YU("Yugoslavia", "YUG", 890, Assignment.TRANSITIONALLY_RESERVED),
 
     /**
@@ -2161,7 +2175,9 @@ public enum CountryCode
      * </p>
      *
      * @see #CD
+     * @deprecated
      */
+    @Deprecated
     ZR("Zaire", "ZAR", 180, Assignment.TRANSITIONALLY_RESERVED),
 
     /**

--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -1800,7 +1800,9 @@ public enum CountryCode
      * <p>
      * Since version 1.17, the numeric code of this entry is 810.
      * </p>
+     * @deprecated 
      */
+    @Deprecated
     SU("USSR", "SUN", 810, Assignment.EXCEPTIONALLY_RESERVED),
 
     /**

--- a/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
@@ -379,6 +379,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     BYR("Belarusian Ruble", 974, 0, CountryCode.BY),
 
     /**
@@ -1154,6 +1155,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     LTL("Lithuanian Litas", 440, 2, CountryCode.LT),
 
     /**
@@ -1258,6 +1260,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     MRO("Ouguiya", 478, 2, CountryCode.MR),
 
     /**
@@ -1605,6 +1608,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     RUR("Russian Ruble", 810, 2, CountryCode.RU),
 
     /**
@@ -1752,6 +1756,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     STD("Dobra", 678, 2, CountryCode.ST),
 
     /**


### PR DESCRIPTION
I want to be able to iterate over CurrencyCodes.values() and ignore the deprecated ones.
It's easier to check for an annotation in code (using Java reflection).