### PR TITLE
Fix javadoc compiler errors and upgrade pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,20 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <jdk.version>[${java.version},)</jdk.version>
+
+        <junit.version>4.13</junit.version>
+
+        <maven-bundle-plugin.version>2.5.3</maven-bundle-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
+        <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>2.10.1</maven-javadoc-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-site-plugin.version>3.6</maven-site-plugin.version>
+        <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
 
     <distributionManagement>
@@ -50,7 +64,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -59,13 +73,14 @@
         <profile>
             <id>doclint</id>
             <activation>
-                <jdk>[1.8,)</jdk>
+                <jdk>${jdk.version}</jdk>
             </activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
                         <configuration>
                             <additionalparam>-Xdoclint:-html</additionalparam>
                         </configuration>
@@ -73,6 +88,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-site-plugin</artifactId>
+                        <version>${maven-site-plugin.version}</version>
                         <configuration>
                             <reportPlugins>
                                 <plugin>
@@ -95,10 +111,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                     <fork>true</fork>
                 </configuration>
             </plugin>
@@ -106,7 +122,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.3</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -120,7 +136,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.1</version>
+                <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <additionalJOption>-J-Duser.language=en</additionalJOption>
                 </configuration>
@@ -137,7 +153,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
+                <version>${maven-jar-plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -150,7 +166,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.4</version>
+                <version>${nexus-staging-maven-plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>darutk</serverId>
@@ -162,7 +178,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>${maven-release-plugin.version}</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>
@@ -174,7 +190,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>${maven-gpg-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -192,7 +208,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>${maven-bundle-plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -1508,7 +1508,7 @@ public enum CountryCode
     NZ("New Zealand", "NZL", 554, Assignment.OFFICIALLY_ASSIGNED),
 
     /**
-     * <a href=http://en.wikipedia.org/wiki/Oman"">Oman</a>
+     * <a href="http://en.wikipedia.org/wiki/Oman">Oman</a>
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#OM">OM</a>, OMN, 512,
      * Officially assigned]
      */
@@ -2343,8 +2343,7 @@ public enum CountryCode
 
 
     /**
-     * Get the <a href="http://en.wikipedia.org/wiki/ISO_3166-1_numeric"
-     * >ISO 3166-1 numeric</a> code.
+     * Get the <a href="http://en.wikipedia.org/wiki/ISO_3166-1_numeric">ISO 3166-1 numeric</a> code.
      *
      * @return
      *         The <a href="http://en.wikipedia.org/wiki/ISO_3166-1_numeric"
@@ -2365,8 +2364,7 @@ public enum CountryCode
      * @return
      *         The assignment state.
      *
-     * @see <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Decoding_table"
-     *       >Decoding table of ISO 3166-1 alpha-2 codes</a>
+     * @see <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Decoding_table">Decoding table of ISO 3166-1 alpha-2 codes</a>
      */
     public Assignment getAssignment()
     {
@@ -2435,6 +2433,7 @@ public enum CountryCode
      *   <td>{@link CountryCode#US CountryCode.US}</td>
      *   <td>{@link Locale#US}</td>
      * </tr>
+     * <caption></caption>
      * </table>
      *
      * <p>
@@ -2782,6 +2781,7 @@ public enum CountryCode
      *   <td><code>ZRCD</code></td>
      *   <td>{@link #ZR}</td>
      * </tr>
+     * <caption></caption>
      * </table>
      * </blockquote>
      *
@@ -2848,6 +2848,7 @@ public enum CountryCode
      *   <td align="center">{@link #TP}</td>
      *   <td align="center">{@link #TL}</td>
      * </tr>
+     * <caption></caption>
      * </table>
      * </blockquote>
      * <br>

--- a/src/main/java/com/neovisionaries/i18n/LanguageAlpha3Code.java
+++ b/src/main/java/com/neovisionaries/i18n/LanguageAlpha3Code.java
@@ -155,6 +155,7 @@ import java.util.regex.Pattern;
  * <td>{@link LanguageAlpha3Code#alb alb}</td>
  * <td><a href="http://en.wikipedia.org/wiki/Albanian_language">Albanian</a></td>
  * </tr>
+ * <caption></caption>
  * </table>
  *
  * <p>
@@ -355,7 +356,7 @@ public enum LanguageAlpha3Code
     alt("Southern Altai"),
 
     /**
-     * <a href="http://en.wikipedia.org/wiki/Atlantic-Congo_languages">Atlantic-Congo languages<a/>
+     * <a href="http://en.wikipedia.org/wiki/Atlantic-Congo_languages">Atlantic-Congo languages</a>
      *
      * @since 1.10
      */
@@ -2259,8 +2260,7 @@ public enum LanguageAlpha3Code
 
     /**
      * <a
-     * href="http://en.wikipedia.org/wiki/Guaran%C3%AD_language">Guaran&iacute
-     * ;</a>
+     * href="http://en.wikipedia.org/wiki/Guaran%C3%AD_language">Guaran&iacute;</a>
      * ({@link LanguageCode#gn gn}).
      */
     grn("Guaran\u00ED")
@@ -4441,7 +4441,7 @@ public enum LanguageAlpha3Code
     pra("Prakrit languages"),
 
     /**
-     * <a href="">Old Proven&ccedil;al</a> (to 1500)
+     * <a href="http://www.example.com">Old Proven&ccedil;al</a> (to 1500)
      *
      * @since 1.10
      */

--- a/src/main/java/com/neovisionaries/i18n/LanguageCode.java
+++ b/src/main/java/com/neovisionaries/i18n/LanguageCode.java
@@ -2595,6 +2595,7 @@ public enum LanguageCode
      *   <td>{@link LanguageCode#zh LanguageCode.zh}</td>
      *   <td>{@link Locale#CHINESE}</td>
      * </tr>
+     * <caption></caption>
      * </table>
      *
      * @return
@@ -2758,6 +2759,7 @@ public enum LanguageCode
      *   <td>{@link LanguageAlpha3Code#alb alb}</td>
      *   <td><a href="http://en.wikipedia.org/wiki/Albanian_language">Albanian</a></td>
      * </tr>
+     * <caption></caption>
      * </table>
      *
      *

--- a/src/main/java/com/neovisionaries/i18n/LocaleCode.java
+++ b/src/main/java/com/neovisionaries/i18n/LocaleCode.java
@@ -1127,6 +1127,7 @@ public enum LocaleCode
      *   <td>{@link LocaleCode#zh_TW LocaleCode.zh_TW}</td>
      *   <td>{@link Locale#TRADITIONAL_CHINESE}</td>
      * </tr>
+     * <caption></caption>
      * </table>
      *
      * <p>
@@ -1280,15 +1281,15 @@ public enum LocaleCode
      * </p>
      *
      * @param language
-     *         <a href="href="http://en.wikipedia.org/wiki/ISO_639-1"
-     *         >ISO 639-1</a> language code. Or "undefined" (case
+     *         <a href="http://en.wikipedia.org/wiki/ISO_639-1">ISO 639-1</a>
+     *         language code. Or "undefined" (case
      *         sensitive). If the given language code is one of legacy
      *         ones { "iw", "ji" and "in" }, it is regarded as its newer
      *         official counterpart { "he", "yi" and "id" }, respectively.
      *
      * @param country
-     *         <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
-     *         >ISO 3166-1 alpha-2</a> country code. Or "UNDEFINED"
+     *         <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>
+     *         country code. Or "UNDEFINED"
      *         (case sensitive).
      *
      * @return
@@ -1312,15 +1313,15 @@ public enum LocaleCode
      * </p>
      *
      * @param language
-     *         <a href="href="http://en.wikipedia.org/wiki/ISO_639-1"
-     *         >ISO 639-1</a> language code. Or "undefined" (case
+     *         <a href="http://en.wikipedia.org/wiki/ISO_639-1">ISO 639-1</a>
+     *         language code. Or "undefined" (case
      *         insensitive). If the given language code is one of legacy
      *         ones { "iw", "ji" and "in" }, it is regarded as its newer
      *         official counterpart { "he", "yi" and "id" }, respectively.
      *
      * @param country
-     *         <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
-     *         >ISO 3166-1 alpha-2</a> country code. Or "UNDEFINED"
+     *         <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>
+     *         country code. Or "UNDEFINED"
      *         (case insensitive).
      *
      * @return
@@ -1346,15 +1347,15 @@ public enum LocaleCode
      * </p>
      *
      * @param language
-     *         <a href="href="http://en.wikipedia.org/wiki/ISO_639-1"
-     *         >ISO 639-1</a> language code. Or "undefined".
+     *         <a href="http://en.wikipedia.org/wiki/ISO_639-1">ISO 639-1</a>
+     *         language code. Or "undefined".
      *         If the given language code is one of legacy ones { "iw",
      *         "ji" and "in" }, it is regarded as its newer official
      *         counterpart { "he", "yi" and "id" }, respectively.
      *
      * @param country
-     *         <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
-     *         >ISO 3166-1 alpha-2</a> country code. Or "UNDEFINED".
+     *         <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>
+     *         country code. Or "UNDEFINED".
      *
      * @param caseSensitive
      *         If {@code true}, the given language code must be lower-case and

--- a/src/main/java/com/neovisionaries/i18n/ScriptCode.java
+++ b/src/main/java/com/neovisionaries/i18n/ScriptCode.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 
 
 /**
- * <a href="http://en.wikipedia.org/wiki/ISO_15924">ISO 15924<a> script code.
+ * <a href="http://en.wikipedia.org/wiki/ISO_15924">ISO 15924</a> script code.
  *
  * @since 1.2
  * @author Takahiko Kawasaki

--- a/src/main/java/com/neovisionaries/i18n/package-info.java
+++ b/src/main/java/com/neovisionaries/i18n/package-info.java
@@ -9,9 +9,10 @@
  * <p>
  * For Maven:
  * </p>
- * <style type="text/css">
+ * <!-- commenting this out because javadoc compiler reports "error: unknown tag: style" -->
+ * <!-- <style type="text/css"> -->
  * span.tag { color: #45818e; }
- * </style>
+ * <!-- </style> -->
  * <pre style="margin: 1em; padding: 0.5em; border: solid 1px black;">
  * <span class="tag">&lt;dependency&gt;
  *     &lt;groupId&gt;</span>com.neovisionaries<span class="tag">&lt;/groupId&gt;


### PR DESCRIPTION
Fix javadoc compiler errors and upgrade pom plugin and dependency versions. Extract these versions to maven properties so that we can use the maven version plugin to update them automatically in the future.