### PR TITLE
XI country code for Northern Ireland

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -2100,6 +2100,13 @@ public enum CountryCode
     WS("Samoa", "WSM", 882, Assignment.OFFICIALLY_ASSIGNED),
 
     /**
+     * <a href="http://en.wikipedia.org/wiki/Northern_Ireland">Northern Ireland</a>
+     * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#XI">XI</a>, XXI, -1,
+     * User assigned]
+     */
+    XI("Northern Ireland", "XXI", -1, Assignment.USER_ASSIGNED),
+
+    /**
      * <a href="http://en.wikipedia.org/wiki/Kosovo">Kosovo, Republic of</a>
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#XK">XK</a>, XXK, -1,
      * User assigned]


### PR DESCRIPTION
This adds the `XI` country code for Northern Ireland. The UK and EU have agreed to use this code after Brexit (January 1st).

See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#XI and https://ec.europa.eu/taxation_customs/sites/taxation/files/use_of_gb_and_xi_codes_guidance.pdf

It's already supported by different software vendors, e.g. https://www.avalara.com/vatlive/en/vat-news/brexit-northern-ireland-vat-and-eoro--xi--number.html

Let me know if I can help in any way. Thanks!