### PR TITLE
Add XU country code for United Kingdom excluding Northern Ireland

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -2109,6 +2109,14 @@ public enum CountryCode
     XI("Northern Ireland", "XXI", -1, Assignment.USER_ASSIGNED),
 
     /**
+     * <a href="http://en.wikipedia.org/wiki/United_Kingdom">United Kingdom (excluding Northern Ireland)</a>
+     * [<a href="https://ec.europa.eu/taxation_customs/sites/taxation/files/use_of_gb_and_xi_codes_guidance.pdf">XU</a>, XXU, -1,
+     * User assigned]
+     *
+     */
+    XU("United Kingdom (excluding Northern Ireland)", null, -1, Assignment.USER_ASSIGNED),
+
+    /**
      * <a href="http://en.wikipedia.org/wiki/Kosovo">Kosovo, Republic of</a>
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#XK">XK</a>, XXK, -1,
      * User assigned]

--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -2114,7 +2114,7 @@ public enum CountryCode
      * User assigned]
      *
      */
-    XU("United Kingdom (excluding Northern Ireland)", null, -1, Assignment.USER_ASSIGNED),
+    XU("United Kingdom (excluding Northern Ireland)", "XXU", -1, Assignment.USER_ASSIGNED),
 
     /**
      * <a href="http://en.wikipedia.org/wiki/Kosovo">Kosovo, Republic of</a>


### PR DESCRIPTION
This adds support for the XU country code which has been created post Brexit to specify the United Kingdom excluding Northern Ireland. 

The new country code is described in more detail in this document: https://ec.europa.eu/taxation_customs/sites/taxation/files/use_of_gb_and_xi_codes_guidance.pdf

The code has not yet been added onto Wikipedia, but will definitely be used going forward according to the new Brexit rules defined [here](https://www.avalara.com/vatlive/en/vat-news/brexit-northern-ireland-vat-and-eoro--xi--number.html), and [here](https://www.douane.gouv.fr/sites/default/files/2020-12/17/note-aux-operateurs-brexit-utilisation-codes-pays-delta-t.pdf).