### PR TITLE
Added country code for United Nations

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -2008,6 +2008,13 @@ public enum CountryCode
      */
     UM("United States Minor Outlying Islands", "UMI", 581, Assignment.OFFICIALLY_ASSIGNED),
 
+    /** <a href="https://en.wikipedia.org/wiki/United_Nations">United Nations</a>
+     * [<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#UN">UN</a>, null, -1,
+     * Exceptionally reserved]
+     * */
+    UN("United Nations", null, -1, Assignment.EXCEPTIONALLY_RESERVED),
+
+
     /**
      * <a href="http://en.wikipedia.org/wiki/United_States">United States</a>
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#US">US</a>, USA, 840,


### PR DESCRIPTION
Hi TakahikoKawasaki,

I've added CountryCode for United Nations according to: ISO 3166
https://www.iso.org/obp/ui/#iso:code:3166:UN
https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#UN

as it is missing in the library ;)