### PR TITLE
Add @Deprecated to CurrencyCode to allow filtering

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
@@ -379,6 +379,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     BYR("Belarusian Ruble", 974, 0, CountryCode.BY),
 
     /**
@@ -1154,6 +1155,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     LTL("Lithuanian Litas", 440, 2, CountryCode.LT),
 
     /**
@@ -1258,6 +1260,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     MRO("Ouguiya", 478, 2, CountryCode.MR),
 
     /**
@@ -1605,6 +1608,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     RUR("Russian Ruble", 810, 2, CountryCode.RU),
 
     /**
@@ -1752,6 +1756,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     STD("Dobra", 678, 2, CountryCode.ST),
 
     /**
@@ -2069,6 +2074,7 @@ public enum CurrencyCode
      *
      * @deprecated
      */
+    @Deprecated
     VEF("Bolivar", 937, 2, CountryCode.VE),
 
     /**

--- a/src/test/java/com/neovisionaries/i18n/CurrencyCodeTest.java
+++ b/src/test/java/com/neovisionaries/i18n/CurrencyCodeTest.java
@@ -22,7 +22,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.Test;
 
 
@@ -178,5 +183,21 @@ public class CurrencyCodeTest
     public void test17()
     {
         assertSame(CurrencyCode.UNDEFINED, getByCode("undefined", false));
+    }
+
+
+    @Test
+    public void test18()
+    {
+        List<CurrencyCode> deprecated = Arrays.stream(CurrencyCode.values()).filter(value -> {
+            try {
+                Field field = CurrencyCode.class.getField(value.name());
+                return field.isAnnotationPresent(Deprecated.class);
+            } catch (NoSuchFieldException | SecurityException e) {
+                return false;
+            }
+        }).collect(Collectors.toList());
+
+        assertTrue(deprecated.containsAll(List.of(CurrencyCode.BYR, CurrencyCode.MRO, CurrencyCode.STD, CurrencyCode.RUR)));
     }
 }


### PR DESCRIPTION
The Java.lang.Deprecated annotaion allows for filtering on deprecated CurrencyCodes