### PR TITLE
Add getByLocale() and toLocale() to ScriptCode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,30 @@
 
     <profiles>
         <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <keyname>E3F58E5C</keyname>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>doclint</id>
             <activation>
                 <jdk>[1.8,)</jdk>
@@ -72,21 +96,28 @@
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-project-info-reports-plugin</artifactId>
+                        <version>3.0.0</version>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-site-plugin</artifactId>
-                        <configuration>
-                            <reportPlugins>
-                                <plugin>
-                                    <groupId>org.apache.maven.plugins</groupId>
-                                    <artifactId>maven-javadoc-plugin</artifactId>
-                                    <configuration>
-                                        <additionalparam>-Xdoclint:-html</additionalparam>
-                                    </configuration>
-                                </plugin>
-                            </reportPlugins>
-                        </configuration>
+                        <version>3.7.1</version>
                     </plugin>
                 </plugins>
             </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:-html</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
         </profile>
     </profiles>
 
@@ -120,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.1</version>
+                <version>2.10.4</version>
                 <configuration>
                     <additionalJOption>-J-Duser.language=en</additionalJOption>
                 </configuration>
@@ -169,24 +200,6 @@
                     <releaseProfiles>release</releaseProfiles>
                     <goals>deploy</goals>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <keyname>E3F58E5C</keyname>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/src/main/java/com/neovisionaries/i18n/ScriptCode.java
+++ b/src/main/java/com/neovisionaries/i18n/ScriptCode.java
@@ -19,6 +19,7 @@ package com.neovisionaries.i18n;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -44,7 +45,14 @@ public enum ScriptCode
      * @see #Zyyy Zyyy: 998 Code for undetermined script
      * @see #Zzzz Zzzz: 999 Code for uncoded script
      */
-    Undefined(-1, "Undefined"),
+    Undefined(-1, "Undefined")
+    {
+        @Override
+        public Locale toLocale()
+        {
+            return LocaleCode.undefined.toLocale();
+        }
+    },
 
     /**
      * Afaka [439]
@@ -1090,6 +1098,23 @@ public enum ScriptCode
 
 
     /**
+     * Convert this {@code ScriptCode} instance to a {@link Locale} instance.
+     *
+     * <p>
+     * This method creates a new {@code Locale} instance
+     * every time it is called.
+     * </p>
+     *
+     * @return
+     *         A {@code Locale} instance that matches this {@code ScriptCode}.
+     * @since 1.30
+     */
+    public Locale toLocale()
+    {
+        return new Locale.Builder().setScript(name()).build();
+    }
+
+    /**
      * Get a {@code ScriptCode} instance that corresponds to the given
      * ISO 15924 alpha-4 code.
      *
@@ -1203,6 +1228,38 @@ public enum ScriptCode
         return numericMap.get(code);
     }
 
+    /**
+     * Get a {@code ScriptCode} that corresponds to the script code of
+     * the given {@link Locale} instance.
+     *
+     * @param locale
+     *         A {@code Locale} instance.
+     *
+     * @return
+     *         A {@code ScriptCode} instance, or {@code null} if not found.
+     *         When {@link Locale#getScript() getScript()} method of the
+     *         given {@code Locale} instance returns {@code null} or an
+     *         empty string, {@link #Undefined ScriptCode.Undefined} is
+     *         returned.
+     *
+     * @see Locale#getScript()
+     */
+    public static ScriptCode getByLocale(Locale locale)
+    {
+        if (locale == null)
+        {
+            return null;
+        }
+
+        String script = locale.getScript();
+
+        if (script.isEmpty())
+        {
+            return ScriptCode.Undefined;
+        }
+
+        return ScriptCode.getByCode(script, true);
+    }
 
     private static String canonicalize(String code, boolean caseSensitive)
     {

--- a/src/test/java/com/neovisionaries/i18n/ScriptCodeTest.java
+++ b/src/test/java/com/neovisionaries/i18n/ScriptCodeTest.java
@@ -16,6 +16,7 @@
 package com.neovisionaries.i18n;
 
 
+import static com.neovisionaries.i18n.ScriptCode.getByLocale;
 import static com.neovisionaries.i18n.ScriptCode.getByCode;
 import static com.neovisionaries.i18n.ScriptCode.getByCodeIgnoreCase;
 import static org.junit.Assert.assertEquals;
@@ -23,8 +24,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import java.util.List;
+import java.util.Locale;
 import org.junit.Test;
-
 
 public class ScriptCodeTest
 {
@@ -400,5 +401,29 @@ public class ScriptCodeTest
     public void test52()
     {
         assertSame(ScriptCode.Undefined, getByCodeIgnoreCase("UNDEFINED"));
+    }
+
+    @Test
+    public void test53()
+    {
+        assertSame(ScriptCode.Undefined, getByLocale(new Locale.Builder().build()));
+    }
+
+    @Test
+    public void test54()
+    {
+        assertSame(ScriptCode.Jpan, getByLocale(new Locale.Builder().setScript(ScriptCode.Jpan.name()).build()));
+    }
+
+    @Test
+    public void test55()
+    {
+        assertSame(ScriptCode.Undefined.toLocale(), new Locale.Builder().build());
+    }
+
+    @Test
+    public void test56()
+    {
+        assertSame(ScriptCode.Jpan.toLocale(), new Locale.Builder().setScript(ScriptCode.Jpan.name()).build());
     }
 }


### PR DESCRIPTION
Add getByLocale(Locale) and toLocale() to ScriptCode. These methods
already exist in CountryCode, LanguageCode, and LocaleCode.

Calling toLocale() always returns a Locale with the just the script
set.

Script support wasn't added to Locale until Java 1.7, so calling
either method will increase the minimum Java version required at
runtime from Java 1.5 to Java 1.7.