### PR TITLE
Added automatic module name to be compatible with JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
                     <archive>
                         <manifestEntries>
                             <Built-By>Neo Visionaries Inc.</Built-By>
+                            <Automatic-Module-Name>com.neovisionaries.i18n</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
I think it is a good idea to have an explicit (though automatic) JPMS module name.  Fixing #64 