### PR TITLE
Add new currency code SLE (925) for Sierra Leone

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CurrencyCode.java
@@ -1707,6 +1707,17 @@ public enum CurrencyCode
     SLL("Leone", 694, 2, CountryCode.SL),
 
     /**
+     * <a href="http://en.wikipedia.org/wiki/Sierra_Leonean_leone">Leone</a>
+     * [numeric code = 925, minor unit = 2]
+     *
+     * <p>Used by:</p>
+     * <ul>
+     * <li>{@link CountryCode#SL SL}: SIERRA LEONE
+     * </ul>
+     */
+    SLE("Leone", 925, 2, CountryCode.SL),
+
+    /**
      * <a href="http://en.wikipedia.org/wiki/Somali_shilling">Somali Shilling</a>
      * [numeric code = 706, minor unit = 2]
      *


### PR DESCRIPTION
As per ISO 4217 amendment 171:

The Sierra Leonean LEONE (SLL) is redenominated by removing three (3) zeros from the
denominations. A new currency code SLE/925 representing the new valuation
(1’000 times old SLL/694) is introduced on 1st April 2022 for any internal needs during the
redenomination process, and is replacing SLL as the official currency code, after the transition
period to be determined.
During this transition period, both the old Leone and new Leone will be in physical circulation
for at least 90 days.
The Bank of Sierra Leone will adopt the new code in the local system but SLL/694 shall
remain in use until further notice.
The Sierra Leonean currency shall continue to be the LEONE and this will not change
after redenomination.

https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl_currency_iso_amendment_171.pdf