### PR TITLE
Changed "North Macedonia, Republic of" to "North Macedonia".

### DIFF
--- a/src/main/java/com/neovisionaries/i18n/CountryCode.java
+++ b/src/main/java/com/neovisionaries/i18n/CountryCode.java
@@ -1302,7 +1302,7 @@ public enum CountryCode
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#MK">MK</a>, MKD, 807,
      * Officially assigned]
      */
-    MK("North Macedonia, Republic of", "MKD", 807, Assignment.OFFICIALLY_ASSIGNED),
+    MK("North Macedonia", "MKD", 807, Assignment.OFFICIALLY_ASSIGNED),
 
     /**
      * <a href="http://en.wikipedia.org/wiki/Mali">Mali</a>


### PR DESCRIPTION
1. https://www.iso.org/obp/ui/#iso:code:3166:MK
2. https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#MK

The name of the country corresponding to the `MK` alpha2 code has been changed from `North Macedonia, Republic of` to `North Macedonia`.

The naming dispute for the previous name `Macedonia, the Former Yugoslav Republic of` of the country has been settled. Like other countries in this list, the title case is the display name for the `LanguageCode` enum constant. For the country with the alpha2 code `MK`, the title case is `North Macedonia`. The `the Republic of` is unnecessary. For convenience in display, this is a valid change.